### PR TITLE
Add --type-only option.

### DIFF
--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -37,6 +37,7 @@ program
 	.option("--endpoint <endpoint>", "path. e.g. https://www.googleapis.com/discovery/v1/apis/urlshortener/v1/rest")
 	.option("--outDir <directory>", "output directory.")
 	.option("--silent", "execute silently.")
+	.option("--type-only", "emit type definition only.")
 	.parse(process.argv);
 
 interface ICommandlineOptions {
@@ -51,6 +52,7 @@ interface ICommandlineOptions {
 
 	outDir: string;
 	silent: boolean;
+	typeOnly: boolean;
 }
 
 var opts:ICommandlineOptions = <any>program;
@@ -236,7 +238,7 @@ function processJsonSchema(data:string) {
 		}
 		return true;
 	}
-	var result = gapidts(JSON.parse(data));
+	var result = gapidts(JSON.parse(data), opts.typeOnly);
 	if (opts.outDir) {
 		mkdirp.sync(opts.outDir);
 		// TODO

--- a/lib/emitter.ts
+++ b/lib/emitter.ts
@@ -18,17 +18,17 @@ export interface IResult {
 	nodejsDefinition:string;
 }
 
-export function emit(root:model.IRestDescription):IResult {
+export function emit(root:model.IRestDescription, typeOnly = false):IResult {
 
 	var base = new Root(root);
 
 	var browser = new GoogleDiscoveryBasedAPIForBrowser();
 	var browserProcess = new Process();
-	walk(browser, browserProcess, base);
+	walk(browser, browserProcess, base, typeOnly);
 
 	var node = new GoogleDiscoveryBasedAPIForNode();
 	var nodeProcess = new Process();
-	walk(node, nodeProcess, base);
+	walk(node, nodeProcess, base, typeOnly);
 
 	return {
 		name: root.name,

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -10,11 +10,11 @@ try {
 } catch (e) {
 }
 
-function gapidts(root:_model.IRestDescription):_emitter.IResult {
+function gapidts(root:_model.IRestDescription, typeOnly = false):_emitter.IResult {
 	if (typeof root === "string") {
 		root = JSON.parse(<any>root);
 	}
-	return _emitter.emit(root);
+	return _emitter.emit(root, typeOnly);
 }
 
 module gapidts {

--- a/lib/plugin/lib/walker.ts
+++ b/lib/plugin/lib/walker.ts
@@ -8,7 +8,7 @@ import Process = require("../../process");
 
 import IPlugin = require("./plugin");
 
-function walk(plugin:IPlugin, process:Process, root:Root) {
+function walk(plugin:IPlugin, process:Process, root:Root, typeOnly = false) {
 	if (!plugin) {
 		throw new Error("plugin parameter required");
 	}
@@ -25,16 +25,18 @@ function walk(plugin:IPlugin, process:Process, root:Root) {
 
 	if (plugin.emitTopLevelModule) {
 		plugin.emitTopLevelModule(process, root, () => {
-			walkDefinition(plugin, process, root);
+			walkDefinition(plugin, process, root, typeOnly);
 		});
 	} else {
-		walkDefinition(plugin, process, root);
+		walkDefinition(plugin, process, root, typeOnly);
 	}
 }
 
-function walkDefinition(plugin:IPlugin, process:Process, root:Root) {
-	root.resources.forEach(resource => walkResource(plugin, process, resource));
-	root.methods.forEach(method => walkMethod(plugin, process, method));
+function walkDefinition(plugin:IPlugin, process:Process, root:Root, typeOnly = false) {
+	if(!typeOnly) {
+		root.resources.forEach(resource => walkResource(plugin, process, resource));
+		root.methods.forEach(method => walkMethod(plugin, process, method));
+	}
 	root.schemas.forEach(schema => plugin.emitType(process, schema));
 }
 


### PR DESCRIPTION
If Google API uses names reserved in typescript, compilation errors occur.
e.g. `get`, `delete`
This option allows me use only interface declarations.
